### PR TITLE
Add model routing topic with routing strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - [Evaluation & Observability](ai-architecture-topics/evaluation-and-observability.md) - Testing, monitoring, and cost tracking
 - [Safety & Security](ai-architecture-topics/safety-and-security.md) - OWASP LLM Top 10, guardrails, and best practices
 - [Orchestration Frameworks](ai-architecture-topics/orchestration-frameworks.md) - LangChain, LangGraph, and workflow tools
+- [Model Routing](ai-architecture-topics/model-routing.md) - Route requests to the right model using rules or ensembles
 
 ### 🎓 Learning Resources
 - [Courses](courses.md) - AI engineering and solution architecture courses
@@ -47,9 +48,10 @@ This repository curates learning resources, certifications, career tips, and int
 ## 🚦 Quick Start
 
 1. **New to AI Architecture?** Start with [AI Architecture Patterns](ai-architecture-topics/ai-architecture-patterns.md)
-2. **Building RAG systems?** Check [Vector Stores & Embeddings](ai-architecture-topics/vector-stores-and-embeddings.md)
-3. **Preparing for interviews?** Jump to [Interview Prep](interview-prep.md)
-4. **Career planning?** Explore [Career Guide](career.md)
+2. **Choosing between models?** Learn [Model Routing](ai-architecture-topics/model-routing.md)
+3. **Building RAG systems?** Check [Vector Stores & Embeddings](ai-architecture-topics/vector-stores-and-embeddings.md)
+4. **Preparing for interviews?** Jump to [Interview Prep](interview-prep.md)
+5. **Career planning?** Explore [Career Guide](career.md)
 
 ## 📖 How to Use This Guide
 

--- a/ai-architecture-topics/ai-architecture-patterns.md
+++ b/ai-architecture-topics/ai-architecture-patterns.md
@@ -69,6 +69,7 @@ AI architecture patterns are reusable blueprints for building intelligent system
 
 ## Next Steps
 - **Learn more**: [Vector Stores & Embeddings](ai-architecture-topics/vector-stores-and-embeddings.md) - How to store and search the knowledge your RAG system needs
+- **Optimize**: [Model Routing](ai-architecture-topics/model-routing.md) - Send each request to the model best suited for it
 - **Try it**: [LangChain Quickstart](https://python.langchain.com/docs/get_started/quickstart) - Build your first AI pipeline in minutes
 - **Connect**: [AI Architecture Community](https://github.com/topics/ai-architecture) - Join discussions about AI system design
 

--- a/ai-architecture-topics/model-routing.md
+++ b/ai-architecture-topics/model-routing.md
@@ -1,0 +1,52 @@
+---
+title: "Model Routing"
+summary: "Direct requests to the best model using rules, confidence scores, or ensembles"
+---
+
+# Model Routing
+
+> Automatically choose the right AI model for each request to balance cost, speed, and quality.
+
+## TL;DR
+- **Model routing** sends each request to the model that's most likely to handle it well.
+- **Rule-based routing** uses simple rules like keywords or metadata to pick a model.
+- **Confidence-based routing** starts with a cheap model and escalates when confidence is low.
+- **Ensemble routing** queries multiple models and combines their answers for better results.
+
+## Quickstart (Do this now)
+1. **List your models**: Note their strengths, costs, and latency.
+2. **Add a router**: Start with simple if/then rules to select models.
+3. **Track confidence**: Measure response quality or uncertainty.
+4. **Fallback smartly**: Re-run low-confidence answers on a stronger model.
+5. **Experiment with ensembles**: Try majority vote or scoring across models.
+
+## The Idea (Slightly deeper)
+Model routing is like having a traffic controller for AI models. Instead of sending every request to the biggest or most expensive model, you route each one to the option that gives the best tradeoff between cost, speed, and accuracy. This can be as simple as keyword rules or as advanced as a learned router model.
+
+## Key Concepts
+- **Rule-based routing**: Hard-coded logic chooses models (e.g., "if query mentions 'code', use a coding model").
+- **Confidence-based routing**: Start with a fast model and only escalate when the answer is uncertain.
+- **Ensemble routing**: Run several models in parallel and combine their outputs (e.g., majority vote or weighted scoring).
+- **Router function**: The component that inspects a request and decides which model(s) to invoke.
+
+## When to Use This
+- **Use when**: You have multiple models with different strengths or costs.
+- **Use when**: You need predictable latency or budget control.
+- **Don't use when**: A single model already meets all requirements.
+- **Consider alternatives**: Tuning one high‑quality model instead of maintaining many.
+
+## Real-World Examples
+- **Rule-based**: OpenAI recommends routing simple tasks to `gpt-3.5` and complex reasoning to `gpt-4` → [OpenAI Model Selection](https://platform.openai.com/docs/guides/text-generation/selecting-model)
+- **Confidence-based**: LlamaIndex's Router Query Engine picks a model based on similarity scores and escalates on low confidence → [LlamaIndex Router](https://docs.llamaindex.ai/en/stable/module_guides/advanced/modules/query_engine/route_query_engine/)
+- **Ensemble**: Self-consistency techniques run multiple model instances and select the most consistent answer → [Self‑Consistency Paper](https://arxiv.org/abs/2203.11171)
+
+## Common Pitfalls
+- **Over-routing**: Too many rules or thresholds can add latency and complexity.
+- **No feedback loop**: Without evaluation, routing decisions may degrade over time.
+- **Cost surprises**: Escalation to expensive models without limits can blow your budget.
+
+## Next Steps
+- **Learn more**: [AI Architecture Patterns](ai-architecture-topics/ai-architecture-patterns.md) - Patterns that often pair with routing strategies
+- **Measure it**: [Evaluation & Observability](ai-architecture-topics/evaluation-and-observability.md) - Track routing quality and costs
+- **Scale it**: [Serving & Scaling](ai-architecture-topics/serving-and-scaling.md) - Deploy routers and models in production
+


### PR DESCRIPTION
## Summary
- add dedicated Model Routing topic covering rule-based, confidence-based, and ensemble strategies
- link model routing from README and AI Architecture Patterns

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68bc9453c17c8329b3e6d0bf8827f30c