### PR TITLE
Add Advanced RAG topic and diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - [Evaluation & Observability](ai-architecture-topics/evaluation-and-observability.md) - Testing, monitoring, and cost tracking
 - [Safety & Security](ai-architecture-topics/safety-and-security.md) - OWASP LLM Top 10, guardrails, and best practices
 - [Orchestration Frameworks](ai-architecture-topics/orchestration-frameworks.md) - LangChain, LangGraph, and workflow tools
+- [Advanced RAG](ai-architecture-topics/advanced-rag.md) - Multi-hop retrieval, rerankers, and feedback loops
 
 ### 🎓 Learning Resources
 - [Courses](courses.md) - AI engineering and solution architecture courses

--- a/ai-architecture-topics/advanced-rag.md
+++ b/ai-architecture-topics/advanced-rag.md
@@ -1,0 +1,62 @@
+---
+title: "Advanced RAG"
+summary: "Boost retrieval-augmented generation accuracy with reranking, multi-hop search, and feedback loops"
+---
+
+# Advanced RAG
+
+> Build RAG systems that move beyond basic vector search using retrieval pipelines, re-rankers, and iterative generation.
+
+![Advanced RAG](/img/advanced-rag.svg)
+
+## TL;DR
+- RAG quality improves when you combine vector search with keyword filters and reranking.
+- Better chunking and multi-hop retrieval reduce hallucinations.
+- Feedback loops and caching keep responses fast and up to date.
+
+## Quickstart (Do this now)
+1. Index your data with both embeddings and keywords.
+2. Add a reranker model to score retrieved passages.
+3. Test multi-step retrieval where one answer triggers another search.
+4. Cache final responses and frequently used chunks.
+5. Evaluate results with a human-reviewed dataset.
+
+## The Idea (Slightly deeper)
+Basic RAG fetches a few documents and feeds them to a model. Advanced RAG adds extra retrieval steps, re-ranks results, and uses query transformations to find better context. By chaining retrieval and generation, the system can research topics, follow citations, or summarize large corpora.
+
+## Diagram
+![Advanced RAG Flow](/img/diagrams/advanced-rag-flow.svg)
+
+## Key Concepts
+- **Query Expansion** – reformulate the question with synonyms or follow-up prompts.
+- **Hybrid Search** – combine dense embeddings with traditional keyword filters.
+- **Reranking** – use a cross-encoder model to score and reorder retrieved chunks.
+- **Multi-Hop Retrieval** – run successive searches to traverse related documents.
+- **Caching** – store useful chunks or final answers to avoid repeated work.
+
+## When to Use
+- When answers require up-to-date or domain-specific knowledge.
+- When basic RAG returns irrelevant or low-quality context.
+- When building assistants that must cite sources or drill into documents.
+- Avoid when a static knowledge base is sufficient or latency is critical.
+
+## Examples
+- [ColBERT](https://github.com/stanford-futuredata/ColBERT) – efficient late interaction reranker for search.
+- [LlamaIndex RAG pipeline](https://github.com/run-llama/llama_index) – modular retrieval chains with query transforms.
+- [OpenAI function calling with retrieval](https://platform.openai.com/docs/guides/function-calling) – letting models decide follow-up searches.
+
+## Pitfalls
+- Ignoring relevance scores can lead to hallucinated answers.
+- Overly small chunks break context; overly large chunks waste tokens.
+- Complex pipelines increase latency and maintenance overhead.
+
+## Deep Dives
+- [RAG triad: retrieval, reranking, generation](https://arxiv.org/abs/2402.19433)
+- [Hybrid search guide](https://www.pinecone.io/learn/hybrid-search/)
+- [Feedback loops for RAG](https://docs.langchain.com/docs/use_cases/toolkits/self-query/)
+
+## Next Steps
+- **Explore**: [Vector Stores & Embeddings](ai-architecture-topics/vector-stores-and-embeddings.md) for better indexing.
+- **Orchestrate**: [Orchestration Frameworks](ai-architecture-topics/orchestration-frameworks.md) to manage multi-step retrieval.
+- **Evaluate**: [Evaluation & Observability](ai-architecture-topics/evaluation-and-observability.md) to measure quality.
+

--- a/img/advanced-rag.svg
+++ b/img/advanced-rag.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+  <rect width="200" height="100" fill="#e0f7fa"/>
+  <text x="100" y="55" text-anchor="middle" font-size="20" fill="#006064">Advanced RAG</text>
+</svg>

--- a/img/diagrams/advanced-rag-flow.svg
+++ b/img/diagrams/advanced-rag-flow.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="120">
+  <rect x="10" y="40" width="80" height="40" fill="#c8e6c9" />
+  <text x="50" y="65" text-anchor="middle" font-size="12">Query</text>
+  <rect x="110" y="40" width="80" height="40" fill="#ffcdd2" />
+  <text x="150" y="65" text-anchor="middle" font-size="12">Retrieve</text>
+  <rect x="210" y="40" width="80" height="40" fill="#bbdefb" />
+  <text x="250" y="65" text-anchor="middle" font-size="12">Generate</text>
+  <line x1="90" y1="60" x2="110" y2="60" stroke="#000" />
+  <line x1="190" y1="60" x2="210" y2="60" stroke="#000" />
+</svg>


### PR DESCRIPTION
## Summary
- document advanced retrieval-augmented generation techniques with quickstart, key concepts, and pitfalls
- include simple overview and flow diagrams for advanced RAG
- link advanced RAG topic from Core Topics in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bc944e0d08832996b2ed63ff6b8ba0