### PR TITLE
Add Databases for AI topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ### 🏗️ Core Topics
 - [AI Architecture Patterns](ai-architecture-topics/ai-architecture-patterns.md) - RAG, agents, pipelines, and orchestration
 - [Vector Stores & Embeddings](ai-architecture-topics/vector-stores-and-embeddings.md) - Storage, retrieval, and similarity search
+- [Databases for AI](ai-architecture-topics/databases-for-ai.md) - Relational tables, vector indexes, feature stores, and metadata catalogs
 - [Serving & Scaling](ai-architecture-topics/serving-and-scaling.md) - Inference servers, GPUs, and autoscaling
 - [Evaluation & Observability](ai-architecture-topics/evaluation-and-observability.md) - Testing, monitoring, and cost tracking
 - [Safety & Security](ai-architecture-topics/safety-and-security.md) - OWASP LLM Top 10, guardrails, and best practices

--- a/ai-architecture-topics/databases-for-ai.md
+++ b/ai-architecture-topics/databases-for-ai.md
@@ -1,0 +1,65 @@
+---
+title: "Databases for AI"
+summary: "Compare relational databases, vector stores, feature stores, and metadata catalogs in AI systems"
+---
+
+# Databases for AI
+
+> Choose the right database technology for each part of your AI stack.
+
+![databases for ai](/img/databases-for-ai.svg)
+
+## TL;DR
+- **Relational databases** store structured records and transactional data.
+- **Vector stores** index embeddings for similarity search.
+- **Feature stores** manage versioned ML features for training and serving.
+- **Metadata catalogs** track datasets, models, and lineage.
+
+## Quickstart (Do this now)
+1. Start with a relational database for source-of-truth business data.
+2. Generate embeddings and load them into a vector store for semantic search.
+3. Use a feature store to share validated features between training and inference.
+4. Register datasets and models in a metadata catalog for discoverability.
+
+## The Idea (Slightly deeper)
+Traditional applications rely on relational databases for consistent transactions and reporting. AI systems add new storage needs:
+- **Vector stores** power RAG and recommendation systems by searching high-dimensional embeddings.
+- **Feature stores** provide a central hub for engineered features, ensuring training/serving consistency.
+- **Metadata catalogs** document datasets, models, and experiments so teams can trace lineage and reuse assets.
+These components complement relational systems rather than replace them.
+
+## Diagram
+![Databases for AI Diagram](/img/diagrams/databases-for-ai.svg)
+
+## Key Concepts
+- **ACID vs. Similarity**: relational DBs guarantee transactions; vector stores focus on nearest neighbor search.
+- **Offline vs. Online Features**: feature stores separate batch-generated features from low-latency serving layers.
+- **Lineage Tracking**: metadata catalogs record where data comes from and how models were built.
+
+## When to Use This
+- **Use when**: Building AI products that mix transactional data with semantic search.
+- **Use when**: Multiple teams need consistent features and dataset governance.
+- **Don't use when**: A single script or prototype can hard-code features and data sources.
+- **Consider alternatives**: Simple object storage or JSON files for small experiments.
+
+## Real-World Examples
+- **PostgreSQL**: Reliable relational database with JSON and vector extensions → [PostgreSQL](https://www.postgresql.org/)
+- **Pinecone**: Managed vector database for semantic search → [Pinecone](https://www.pinecone.io/)
+- **Feast**: Open-source feature store → [Feast](https://feast.dev/)
+- **MLflow Model Registry**: Metadata catalog for model tracking → [MLflow](https://mlflow.org/)
+
+## Common Pitfalls
+- **Embedding drift**: forgetting to reindex vector stores when models change.
+- **Feature skew**: training and serving pipelines calculate features differently.
+- **Untracked experiments**: losing lineage by skipping metadata catalogs.
+
+## Deep Dives & "Why it's awesome"
+- **[Postgres pgvector Extension](https://github.com/pgvector/pgvector)** - Add vector search to a familiar relational DB.
+- **[Feast Architecture](https://docs.feast.dev/)** - How feature stores manage offline and online data.
+- **[MLflow Tracking](https://mlflow.org/docs/latest/tracking.html)** - Record experiments and model artifacts.
+
+## Next Steps
+- **Learn more**: [Vector Stores & Embeddings](ai-architecture-topics/vector-stores-and-embeddings.md) - Dig into similarity search.
+- **Try it**: [Feast Quickstart](https://docs.feast.dev/getting-started/quickstart) - Build your first feature repository.
+- **Connect**: [OpenML Metadata](https://www.openml.org/) - Explore community datasets and metadata.
+

--- a/img/databases-for-ai.svg
+++ b/img/databases-for-ai.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400">
+  <rect width="800" height="400" fill="#f0f4f8"/>
+  <text x="400" y="160" font-size="36" text-anchor="middle" fill="#333">Databases for AI</text>
+  <text x="400" y="220" font-size="20" text-anchor="middle" fill="#555">Relational • Vector • Feature • Metadata</text>
+</svg>

--- a/img/diagrams/databases-for-ai.svg
+++ b/img/diagrams/databases-for-ai.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400">
+  <rect width="800" height="400" fill="#ffffff"/>
+  <!-- Boxes -->
+  <rect x="40" y="40" width="160" height="60" fill="#d6eaf8" stroke="#333"/>
+  <text x="120" y="75" font-size="16" text-anchor="middle" fill="#333">Relational DB</text>
+
+  <rect x="600" y="40" width="160" height="60" fill="#fdebd0" stroke="#333"/>
+  <text x="680" y="75" font-size="16" text-anchor="middle" fill="#333">Vector Store</text>
+
+  <rect x="40" y="300" width="160" height="60" fill="#d5f5e3" stroke="#333"/>
+  <text x="120" y="335" font-size="16" text-anchor="middle" fill="#333">Feature Store</text>
+
+  <rect x="600" y="300" width="160" height="60" fill="#f9e79f" stroke="#333"/>
+  <text x="680" y="335" font-size="16" text-anchor="middle" fill="#333">Metadata Catalog</text>
+
+  <rect x="310" y="160" width="180" height="80" fill="#e8daef" stroke="#333"/>
+  <text x="400" y="205" font-size="16" text-anchor="middle" fill="#333">AI Application</text>
+
+  <!-- Arrows -->
+  <line x1="200" y1="70" x2="310" y2="200" stroke="#555" marker-end="url(#arrow)"/>
+  <line x1="600" y1="70" x2="490" y2="200" stroke="#555" marker-end="url(#arrow)"/>
+  <line x1="200" y1="330" x2="310" y2="200" stroke="#555" marker-end="url(#arrow)"/>
+  <line x1="600" y1="330" x2="490" y2="200" stroke="#555" marker-end="url(#arrow)"/>
+
+  <!-- Arrow definition -->
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,5 L0,10 z" fill="#555"/>
+    </marker>
+  </defs>
+</svg>


### PR DESCRIPTION
## Summary
- add Databases for AI guide covering relational DBs, vector stores, feature stores, and metadata catalogs
- include overview and diagram images
- update README table of contents with Databases for AI section

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bc94572c3c8329b4386b05db03c437