### PR TITLE
Add inference infrastructure topic and cross-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [AI Architecture Patterns](ai-architecture-topics/ai-architecture-patterns.md) - RAG, agents, pipelines, and orchestration
 - [Vector Stores & Embeddings](ai-architecture-topics/vector-stores-and-embeddings.md) - Storage, retrieval, and similarity search
 - [Serving & Scaling](ai-architecture-topics/serving-and-scaling.md) - Inference servers, GPUs, and autoscaling
+- [Inference Infrastructure](ai-architecture-topics/inference-infrastructure.md) - GPUs, TPUs, quantization, and cost-performance metrics
 - [Evaluation & Observability](ai-architecture-topics/evaluation-and-observability.md) - Testing, monitoring, and cost tracking
 - [Safety & Security](ai-architecture-topics/safety-and-security.md) - OWASP LLM Top 10, guardrails, and best practices
 - [Orchestration Frameworks](ai-architecture-topics/orchestration-frameworks.md) - LangChain, LangGraph, and workflow tools

--- a/ai-architecture-topics/inference-infrastructure.md
+++ b/ai-architecture-topics/inference-infrastructure.md
@@ -1,0 +1,54 @@
+---
+title: "Inference Infrastructure"
+summary: "Select the right hardware and optimizations for fast, cost-effective model serving"
+---
+
+# Inference Infrastructure
+
+> Choose GPUs, TPUs, and model optimizations that deliver the best performance for your budget.
+
+## TL;DR
+- **GPUs vs TPUs**: GPUs offer broad framework support while TPUs deliver high throughput for supported models.
+- **Quantization** shrinks model size, fitting more instances on a device with minor accuracy trade-offs.
+- **Cost-performance metrics** like tokens-per-second-per-dollar keep infrastructure efficient.
+
+## Quickstart (Do this now)
+1. **Profile hardware**: Benchmark GPUs, TPUs, or CPUs for your model.
+2. **Apply quantization**: Use INT8 or FP8 formats to cut memory use.
+3. **Measure throughput**: Track tokens/sec and latency across configs.
+4. **Calculate cost**: Divide hourly instance price by tokens served to gauge efficiency.
+5. **Monitor utilization**: Watch GPU/TPU usage to right-size instances.
+
+## The Idea (Slightly deeper)
+Picking the right accelerator balances raw speed, memory capacity, and framework compatibility. Quantization techniques reduce precision to lower memory and compute needs. Tracking cost against performance ensures the chosen setup scales sustainably.
+
+## Key Concepts
+- **Accelerator Selection**: Comparing NVIDIA GPUs, Google TPUs, and CPU alternatives.
+- **Memory Bandwidth**: Impacts how quickly models read data during inference.
+- **Model Quantization**: INT8, FP8, and sparsity to shrink model footprints.
+- **Throughput Metrics**: Tokens/sec, latency, and cost per million tokens.
+- **Utilization**: Keeping devices busy to avoid paying for idle capacity.
+
+## When to Use This
+- **Use when**: Deploying models with strict latency or cost requirements.
+- **Use when**: Deciding between on-prem and cloud accelerators.
+- **Don't use when**: Prototyping small models on a laptop.
+- **Consider alternatives**: Managed inference services for minimal ops overhead.
+
+## Real-World Examples
+- **NVIDIA A100**: Versatile GPU with strong mixed-precision support → [A100](https://www.nvidia.com/en-us/data-center/a100/)
+- **Google TPU v5e**: High throughput for transformer workloads → [TPU v5e](https://cloud.google.com/tpu/docs/system-architecture-tpu-vm#v5e)
+- **GPTQ**: Popular open-source quantization method → [GPTQ](https://github.com/IST-DASLab/gptq)
+- **AWS Inferentia2**: Custom silicon optimized for large language models → [Inferentia2](https://aws.amazon.com/machine-learning/inferentia/)
+
+## Common Pitfalls
+- **Overprovisioning**: Paying for accelerators that sit idle.
+- **Unsupported quantization**: Some models lose too much accuracy or fail to run.
+- **Ignoring bandwidth**: Fast cores are wasted if memory can't keep up.
+- **No cost tracking**: Missing tokens-per-dollar metrics hides inefficiency.
+
+## Next Steps
+- **Learn more**: [Serving & Scaling](ai-architecture-topics/serving-and-scaling.md) - Deploy optimized models in production
+- **Measure**: [Evaluation & Observability](ai-architecture-topics/evaluation-and-observability.md) - Monitor latency and spending
+- **Explore**: [Orchestration Frameworks](ai-architecture-topics/orchestration-frameworks.md) - Manage multi-model pipelines
+

--- a/ai-architecture-topics/serving-and-scaling.md
+++ b/ai-architecture-topics/serving-and-scaling.md
@@ -78,6 +78,7 @@ summary: "Deploy AI models in production with inference servers, GPU optimizatio
 - **Optimize network**: Minimize data transfer between services
 
 ## Next Steps
+- **Dive into hardware**: [Inference Infrastructure](ai-architecture-topics/inference-infrastructure.md) - Choose accelerators and quantization strategies
 - **Learn more**: [Orchestration Frameworks](ai-architecture-topics/orchestration-frameworks.md) - How to coordinate multiple AI services
 - **Try it**: [vLLM Quickstart](https://docs.vllm.ai/en/latest/getting_started/quickstart.html) - Deploy your first high-performance inference server
 - **Connect**: [AI Inference Community](https://github.com/topics/ai-inference) - Join discussions about AI model serving


### PR DESCRIPTION
## Summary
- Add inference infrastructure guide covering hardware selection, model quantization, and cost-performance metrics.
- Link the new guide from the Serving & Scaling page and list it in the README core topics.

## Testing
- `npm test` (fails: missing package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68bc945fed0883299fcf7c424cbd63f8