### PR TITLE
Add red teaming topic and cross-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Serving & Scaling](ai-architecture-topics/serving-and-scaling.md) - Inference servers, GPUs, and autoscaling
 - [Evaluation & Observability](ai-architecture-topics/evaluation-and-observability.md) - Testing, monitoring, and cost tracking
 - [Safety & Security](ai-architecture-topics/safety-and-security.md) - OWASP LLM Top 10, guardrails, and best practices
+- [Red Teaming](ai-architecture-topics/red-teaming.md) - Scenario generation, attack simulations, and reporting workflows
 - [Orchestration Frameworks](ai-architecture-topics/orchestration-frameworks.md) - LangChain, LangGraph, and workflow tools
 
 ### 🎓 Learning Resources

--- a/ai-architecture-topics/red-teaming.md
+++ b/ai-architecture-topics/red-teaming.md
@@ -1,0 +1,48 @@
+---
+title: "Red Teaming"
+summary: "Simulate adversarial scenarios, run attack simulations, and report findings to harden AI systems"
+---
+
+# Red Teaming
+
+> Stress-test your AI system by acting like an attacker and documenting what you find.
+
+![ai architect red teaming](/img/red-teaming.png)
+
+## TL;DR
+- **Scenario generation** creates what-if cases that expose blind spots.
+- **Attack simulations** emulate real adversaries to test defenses.
+- **Reporting workflows** capture findings and track mitigation.
+
+## Quickstart (Do this now)
+1. **Generate scenarios**: Brainstorm or use tools to create malicious prompt and system abuse cases.
+2. **Simulate attacks**: Execute prompts or requests that mimic adversarial behavior.
+3. **Report findings**: Record issues, severity, and fixes in a shared log.
+
+## The Idea (Slightly deeper)
+Red teaming treats your AI system as if you were an attacker. By generating diverse scenarios and running structured attack simulations, teams discover vulnerabilities before real adversaries do. A formal reporting workflow ensures problems are documented and addressed.
+
+## Key Concepts
+- **Scenario Generation**: Building realistic misuse cases and edge situations.
+- **Attack Simulations**: Running prompts or requests that attempt to bypass protections.
+- **Reporting Workflows**: Standardizing how vulnerabilities are logged, triaged, and remediated.
+- **Collaboration**: Red teams (attackers) and blue teams (defenders) working together.
+
+## When to Use This
+- **Use when**: Launching public AI features or handling sensitive data.
+- **Use when**: Evaluating safety controls like guardrails or moderation.
+- **Don't use when**: Prototyping low-risk internal experiments.
+
+## Real-World Examples
+- **OpenAI Red Teaming Network** → [OpenAI Red Teaming Network](https://openai.com/red-teaming-network) (community experts probing models before release)
+- **MITRE ATLAS** → [MITRE ATLAS](https://atlas.mitre.org/) (knowledge base of adversary tactics for ML)
+- **Hugging Face Red Teaming** → [Hugging Face Red Teaming](https://huggingface.co/docs/red-teaming/index) (guidance for model evaluation)
+
+## Common Pitfalls
+- **Incomplete scenarios**: Missing domain-specific abuse cases.
+- **No follow-up**: Failing to track mitigation after reporting.
+- **One-off efforts**: Skipping regular retesting after fixes.
+
+## Next Steps
+- **Learn more**: [Safety & Security](safety-and-security.md) – Guardrails and best practices to protect your system.
+- **Monitor**: [Evaluation & Observability](evaluation-and-observability.md) – Measure how fixes perform over time.

--- a/ai-architecture-topics/safety-and-security.md
+++ b/ai-architecture-topics/safety-and-security.md
@@ -69,6 +69,7 @@ AI systems can be tricked, hacked, or made to do harmful things if not properly 
 - **[LangChain Security Guide](https://python.langchain.com/docs/security/)** - How to build secure applications with LangChain and best practices
 
 ## Next Steps
+- **Test defenses**: [Red Teaming](ai-architecture-topics/red-teaming.md) - Scenario generation, attack simulations, and reporting workflows
 - **Learn more**: [Evaluation & Observability](ai-architecture-topics/evaluation-and-observability.md) - How to monitor your AI system for security issues
 - **Try it**: [NeMo Guardrails Quickstart](https://docs.anyscale.com/guardrails/getting-started) - Add safety to your AI app in minutes
 - **Connect**: [AI Security Community](https://github.com/topics/ai-security) - Join discussions about AI safety and security


### PR DESCRIPTION
## Summary
- add red teaming topic covering scenario generation, attack simulations, and reporting workflows
- cross-link red teaming with safety and security
- include red teaming in main README table of contents

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bc946800ac83299d5a5a9db88e4e86