### PR TITLE
Add Data Lakes & Marts topic with diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - [Evaluation & Observability](ai-architecture-topics/evaluation-and-observability.md) - Testing, monitoring, and cost tracking
 - [Safety & Security](ai-architecture-topics/safety-and-security.md) - OWASP LLM Top 10, guardrails, and best practices
 - [Orchestration Frameworks](ai-architecture-topics/orchestration-frameworks.md) - LangChain, LangGraph, and workflow tools
+- [Data Lakes & Marts](ai-architecture-topics/data-lakes-and-marts.md) - Lakehouse concepts, ETL/ELT pipelines, and governance
 
 ### 🎓 Learning Resources
 - [Courses](courses.md) - AI engineering and solution architecture courses

--- a/ai-architecture-topics/data-lakes-and-marts.md
+++ b/ai-architecture-topics/data-lakes-and-marts.md
@@ -1,0 +1,65 @@
+---
+title: "Data Lakes & Marts"
+summary: "Understand lakehouse architectures, ETL/ELT pipelines, and data governance for AI systems"
+---
+
+# Data Lakes & Marts
+
+> Store, transform, and serve data for AI workloads using scalable lakehouse patterns and governed data marts.
+
+![ai architect data lakes and marts](/img/data-lakes-and-marts.svg)
+
+## TL;DR
+- **Data lakes** hold raw, large-scale data in open formats.
+- **Data marts** are curated subsets optimized for analytics and ML.
+- **Lakehouse** architectures blend the flexibility of lakes with warehouse reliability.
+- **Governance** keeps data secure, high-quality, and compliant.
+
+## Quickstart (Do this now)
+1. **Ingest** data from sources into a cloud object store (your data lake)
+2. **Transform** with ETL/ELT jobs to apply schema, quality checks, and partitions
+3. **Publish** governed data marts for BI dashboards or model training
+4. **Track lineage** and permissions to ensure trust and compliance
+
+## The Idea (Slightly deeper)
+A **lakehouse** combines data lake scalability with warehouse structure. Raw data lands in the lake, then ETL/ELT pipelines refine it into structured tables while preserving history. **Data marts** provide domain-specific views that teams can use without touching the raw lake. Robust **governance**—covering cataloging, quality, access, and retention—prevents data swamps and enables regulated AI use.
+
+## Diagram
+![Data Lakes and Marts Flow](/img/diagrams/data-lakes-and-marts.svg)
+
+## Key Concepts
+- **Lakehouse storage**: ACID tables on top of low-cost object stores
+- **ETL vs ELT**: Transform before or after loading into the lakehouse
+- **Data marts**: Curated subsets for analytics or model features
+- **Governance**: Metadata catalogs, quality rules, and access controls
+- **Lineage**: Tracing data from source to consumption for trust
+
+## When to Use This
+- **Use when**: You need one source of truth for both analytics and ML
+- **Use when**: Teams require domain-specific slices of enterprise data
+- **Don't use when**: A single, small database covers all needs
+- **Consider alternatives**: Traditional data warehouses for simpler workloads
+
+## Real-World Examples
+- **Delta Lake** on Databricks for lakehouse tables
+- **BigQuery** and **Snowflake** for managed lakehouse features
+- **Apache Iceberg** or **Hudi** for open table formats
+
+## Common Pitfalls
+- **Unmanaged data sprawl** leading to a "data swamp"
+- **Missing governance** causing security or compliance issues
+- **Slow pipelines** from overcomplicated ETL/ELT jobs
+- **Duplicated data marts** without clear ownership
+
+## Deep Dives & "Why it's awesome"
+- **[Delta Lake](https://delta.io/)** - Adds reliability and ACID compliance to data lakes
+- **[BigQuery Lakehouse](https://cloud.google.com/bigquery/docs/introduction)** - Serverless lakehouse with built-in governance
+- **[Snowflake](https://www.snowflake.com/en/data-lake/)** - Cloud data platform supporting lakehouse patterns
+- **[Apache Iceberg](https://iceberg.apache.org/)** - Open table format with schema evolution and time travel
+- **[Data Mesh](https://martinfowler.com/articles/data-mesh-principles.html)** - Decentralized governance for domain data products
+
+## Next Steps
+- **Learn more**: [Evaluation & Observability](evaluation-and-observability.md) - Monitor data quality and pipeline health
+- **Try it**: Build a simple lakehouse using Delta Lake and a cloud object store
+- **Connect**: Explore [awesome data engineering](https://github.com/igorbarinov/awesome-data-engineering) resources
+

--- a/img/data-lakes-and-marts.svg
+++ b/img/data-lakes-and-marts.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="120" viewBox="0 0 400 120">
+  <rect width="400" height="120" fill="#EEF2FF"/>
+  <text x="200" y="65" font-size="24" text-anchor="middle" fill="#1F2937">Data Lakes &amp; Marts</text>
+</svg>

--- a/img/diagrams/data-lakes-and-marts.svg
+++ b/img/diagrams/data-lakes-and-marts.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="200">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,5 L0,10 z" fill="#374151"/>
+    </marker>
+  </defs>
+  <rect x="10" y="70" width="100" height="60" fill="#A7F3D0" stroke="#10B981"/>
+  <text x="60" y="105" text-anchor="middle" font-size="12">Data Sources</text>
+  <line x1="110" y1="100" x2="170" y2="100" stroke="#374151" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="170" y="70" width="100" height="60" fill="#BFDBFE" stroke="#3B82F6"/>
+  <text x="220" y="105" text-anchor="middle" font-size="12">ETL/ELT</text>
+  <line x1="270" y1="100" x2="330" y2="100" stroke="#374151" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="330" y="70" width="100" height="60" fill="#FDE68A" stroke="#F59E0B"/>
+  <text x="380" y="105" text-anchor="middle" font-size="12">Lakehouse</text>
+  <line x1="430" y1="100" x2="490" y2="100" stroke="#374151" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="490" y="70" width="100" height="60" fill="#FCA5A5" stroke="#EF4444"/>
+  <text x="540" y="105" text-anchor="middle" font-size="12">Data Marts</text>
+</svg>


### PR DESCRIPTION
## Summary
- add Data Lakes & Marts guide covering lakehouse patterns, ETL/ELT pipelines, and governance
- include simple SVG diagrams for data lakehouse flows
- update README with link to the new topic

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68bc94769eb883298ce6c6835b4bffd8