### PR TITLE
Add AI workflow automation topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - [Evaluation & Observability](ai-architecture-topics/evaluation-and-observability.md) - Testing, monitoring, and cost tracking
 - [Safety & Security](ai-architecture-topics/safety-and-security.md) - OWASP LLM Top 10, guardrails, and best practices
 - [Orchestration Frameworks](ai-architecture-topics/orchestration-frameworks.md) - LangChain, LangGraph, and workflow tools
+- [AI Workflow Automation](ai-architecture-topics/ai-workflow-automation.md) - DAG schedulers and model CI/CD
 
 ### 🎓 Learning Resources
 - [Courses](courses.md) - AI engineering and solution architecture courses

--- a/ai-architecture-topics/ai-workflow-automation.md
+++ b/ai-architecture-topics/ai-workflow-automation.md
@@ -1,0 +1,57 @@
+---
+title: "AI Workflow Automation"
+summary: "Automate model pipelines with DAG schedulers like Airflow or Prefect and integrate CI/CD for continuous model delivery"
+---
+
+# AI Workflow Automation
+
+> Automate the boring stuff: schedule data and model tasks and push new models to production safely.
+
+## TL;DR
+- **DAG schedulers** such as **Apache Airflow** and **Prefect** run your data and training steps in order and on schedule.
+- **CI/CD for models** treats model code and artifacts like software so updates flow through tests and deployments automatically.
+- Use both to keep AI systems reliable, reproducible, and easy to update.
+
+## Quickstart (Do this now)
+1. **Pick a scheduler**: Start with [Apache Airflow](https://airflow.apache.org/) or [Prefect](https://www.prefect.io/).
+2. **Define a DAG**: Model your workflow as tasks with dependencies (e.g., ingest → train → evaluate → deploy).
+3. **Version control**: Store pipeline code and model configs in Git.
+4. **Add CI steps**: Run unit tests and linting on every commit.
+5. **Automate deployment**: Use a registry and deployment script to push approved models.
+6. **Monitor runs**: Track DAG executions and model performance over time.
+
+## The Idea (Slightly deeper)
+**Directed Acyclic Graph (DAG) schedulers** break work into small tasks and run them in order based on dependencies. They handle retries, scheduling, and logging so you can focus on the logic of each step.
+
+**Model CI/CD** extends software delivery practices to machine learning. Every change to data processing, training code, or model parameters goes through automated tests and staging before production. Combining schedulers with CI/CD ensures that new models are built, evaluated, and deployed in a repeatable way.
+
+For orchestrating multi-service AI applications, see [Orchestration Frameworks](orchestration-frameworks.md).
+
+## Key Concepts
+- **DAG**: A graph of tasks with no cycles that defines execution order.
+- **Task retry**: Automatic reruns when a step fails.
+- **Model registry**: Central store for versioned models.
+- **Continuous delivery**: Every valid change can deploy automatically after tests.
+
+## When to Use This
+- **Use when**: You retrain models regularly or maintain complex data pipelines.
+- **Use when**: Multiple teams collaborate on data and model code.
+- **Don't use when**: Your model is static and rarely updated.
+- **Consider alternatives**: Simple cron jobs for single scripts without dependencies.
+
+## Real-World Examples
+- **Airflow managing training pipelines** → [Airflow](https://airflow.apache.org/) (mature scheduler with rich UI)
+- **Prefect for dataflow and ML** → [Prefect](https://www.prefect.io/) (cloud-ready workflow runner)
+- **GitHub Actions for model CI** → [GitHub Actions](https://docs.github.com/en/actions) (tests and deploys models on push)
+- **MLflow Model Registry** → [MLflow](https://mlflow.org/) (track, compare, and deploy models)
+
+## Common Pitfalls
+- **Hard-coded paths**: Parameterize everything so pipelines work in different environments.
+- **Skipping tests**: Models without CI can break silently in production.
+- **No rollback plan**: Always keep a known-good model to revert to.
+
+## Next Steps
+- **Learn more**: [Orchestration Frameworks](orchestration-frameworks.md) – coordinate multi-model workflows after your pipelines run.
+- **Try it**: [Prefect Tutorial](https://docs.prefect.io/latest/getting-started/quickstart/) – build your first flow in minutes.
+- **Connect**: [MLOps Community](https://mlops.community/) – discuss best practices for model delivery.
+

--- a/ai-architecture-topics/orchestration-frameworks.md
+++ b/ai-architecture-topics/orchestration-frameworks.md
@@ -77,6 +77,7 @@ summary: "Coordinate multiple AI services and build complex workflows using orch
 
 ## Next Steps
 - **Learn more**: [AI Architecture Patterns](ai-architecture-topics/ai-architecture-patterns.md) - How to design the workflows your orchestration framework will manage
+- **Automate pipelines**: [AI Workflow Automation](ai-workflow-automation.md) - DAG schedulers and model CI/CD
 - **Try it**: [LangChain Quickstart](https://python.langchain.com/docs/get_started/quickstart) - Build your first AI workflow in minutes
 - **Connect**: [AI Orchestration Community](https://github.com/topics/ai-orchestration) - Join discussions about AI workflow management
 


### PR DESCRIPTION
## Summary
- add AI workflow automation guide on DAG schedulers and model CI/CD
- link orchestration frameworks to workflow automation
- include workflow automation in README table of contents

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bc9479054c8329be855a0495b4a7ea