### PR TITLE
Add genetic memory topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - [Evaluation & Observability](ai-architecture-topics/evaluation-and-observability.md) - Testing, monitoring, and cost tracking
 - [Safety & Security](ai-architecture-topics/safety-and-security.md) - OWASP LLM Top 10, guardrails, and best practices
 - [Orchestration Frameworks](ai-architecture-topics/orchestration-frameworks.md) - LangChain, LangGraph, and workflow tools
+- [Genetic Memory](ai-architecture-topics/genetic-memory.md) - Vector memory, knowledge graphs, and retention
 
 ### 🎓 Learning Resources
 - [Courses](courses.md) - AI engineering and solution architecture courses

--- a/ai-agents.md
+++ b/ai-agents.md
@@ -1,0 +1,22 @@
+---
+title: "AI Agents"
+summary: "Design autonomous agents with planning and memory"
+---
+
+# AI Agents
+
+> Build AI agents that can plan, reason, and remember.
+
+## TL;DR
+- **Agent planning** breaks goals into steps and tools.
+- **Genetic memory** gives agents long-term recall through vectors and knowledge graphs.
+
+## Quickstart (Do this now)
+1. **Pick a framework**: Start with LangChain, AutoGen, or similar agent toolkit.
+2. **Add memory**: Use [Genetic Memory](ai-architecture-topics/genetic-memory.md) to persist and retrieve context.
+3. **Test planning**: Give your agent multi-step tasks and refine its tool usage.
+
+## Next Steps
+- Explore more in [Genetic Memory](ai-architecture-topics/genetic-memory.md).
+- Learn about [AI Architecture Patterns](ai-architecture-topics/ai-architecture-patterns.md) for orchestrating agents.
+

--- a/ai-architecture-topics/genetic-memory.md
+++ b/ai-architecture-topics/genetic-memory.md
@@ -1,0 +1,50 @@
+---
+title: "Genetic Memory"
+summary: "Combine vector stores, knowledge graphs, and retention policies for adaptive agent memory"
+---
+
+# Genetic Memory
+
+> Design memory systems for AI agents that evolve over time and stay relevant.
+
+## TL;DR
+- **Vector-based memory** stores experiences as embeddings so agents can recall similar situations quickly.
+- **Knowledge graph integration** links memories to structured entities and relationships for richer reasoning.
+- **Retention policies** decide what to keep, compress, or forget so memory stays useful and affordable.
+
+## Quickstart (Do this now)
+1. **Capture interactions**: Convert conversations or events into embeddings and store them in a vector database.
+2. **Link to a graph**: Connect each memory to entities and relationships in a knowledge graph like Neo4j.
+3. **Define retention rules**: Keep recent or high-value memories, archive or delete the rest on a schedule.
+4. **Retrieve by context**: Use similarity search plus graph traversal to fetch relevant memories during planning.
+5. **Review periodically**: Prune stale data and regenerate embeddings as models or schemas evolve.
+
+## The Idea (Slightly deeper)
+Vector memory lets agents recall by meaning, while knowledge graphs provide structured context. Combining them gives both fuzzy recall and precise reasoning. Retention policies prevent unbounded growth by applying heuristics like time-to-live, relevance scoring, or summarization.
+
+## Key Concepts
+- **Vector-Based Memory**: Embedding-driven store that retrieves semantically similar past interactions.
+- **Knowledge Graph Integration**: Mapping memories to entities/relations so agents can reason over connected facts.
+- **Retention Policies**: Rules for pruning, summarizing, or archiving memories to control cost and relevance.
+
+## When to Use This
+- **Use when**: Building agents that learn from ongoing interactions and need long-term context.
+- **Use when**: You require both semantic recall and explicit reasoning over entities.
+- **Don't use when**: A simple stateless chatbot is sufficient.
+- **Consider alternatives**: Session-based memory or fixed context windows for short-lived assistants.
+
+## Real-World Examples
+- **MemGPT** combines vector stores with summarization to maintain a growing memory.
+- **LangChain** offers memory modules that hook into knowledge graphs and vector databases.
+- **Custom agents** storing conversation vectors in Pinecone and facts in Neo4j with scheduled pruning jobs.
+
+## Common Pitfalls
+- **Unbounded growth**: Without retention, memory size and costs explode.
+- **Stale knowledge**: Memories can become outdated—revalidate or summarize periodically.
+- **Privacy leaks**: Sensitive data may persist; apply encryption and deletion policies.
+
+## Next Steps
+- **Learn more**: [Vector Stores & Embeddings](vector-stores-and-embeddings.md) – foundations of vector-based recall
+- **Explore**: [AI Architecture Patterns](ai-architecture-patterns.md) – how memory fits into larger systems
+- **Connect**: [Safety & Security](safety-and-security.md) – policies for handling sensitive memories
+


### PR DESCRIPTION
## Summary
- add genetic memory page covering vector memory, knowledge graphs, and retention policies
- introduce AI agents page linking to genetic memory
- surface genetic memory in the main README

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68bc94801610832988d69d55eeaa9b62