### PR TITLE
docs(adr): add Mneme HQ to ADR Resources

### DIFF
--- a/solution-architecture/architecture-decision-records.md
+++ b/solution-architecture/architecture-decision-records.md
@@ -236,6 +236,7 @@ We will use PostgreSQL as our primary database technology.
 - [Michael Nygard's ADR Template](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
 - [Arachne Framework ADR Repository](https://github.com/arachne-framework/architecture)
 - [Log4Brains Tool](https://github.com/thomvaill/log4brains)
+- [Mneme HQ](https://github.com/TheoV823/mneme) - ADR enforcement for AI coding agents. Turns ADRs into deterministic pre-generation checks for Claude Code, Cursor, and Copilot.
 
 ## Related Topics
 


### PR DESCRIPTION
## What

Adds [Mneme HQ](https://github.com/TheoV823/mneme) to the Resources section of `solution-architecture/architecture-decision-records.md`.

## Why

Mneme is an open-source tool for enforcing ADRs in AI-assisted development. It turns architecture decisions into deterministic pre-generation checks for Claude Code, Cursor, and Copilot — bridging the gap between ADRs as documentation and ADRs as enforceable contracts when AI agents are writing the code.

Fits naturally alongside the existing entries (Michael Nygard's template, MADR, Log4Brains) as a practical tool readers exploring ADRs may want to know about.

## License & compliance

- MIT-licensed, actively maintained.
- One-line entry, factual framing, no marketing copy.

Happy to revise framing or placement if you'd prefer a different section.